### PR TITLE
Split python into separate script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Changed
 - "Dogfood" action to check itself
+- Move python code out of workflow file
 
 ## [v1.0.0] - 2024-04-18
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # The exact version doesn't matter, so just use whatever is already
+    # available in the runner
+    - uses: actions/setup-python@v5
+
     # https://github.com/orgs/community/discussions/9049#discussioncomment-4239509
     # Due to limitations on composite Actions, we can't do something like:
     # - uses: docker://ghcr.io/uclahs-cds/cicd-base:${{ inputs.docker-tag }}
@@ -22,29 +26,9 @@ runs:
     # There absolutely should not be an 'action.yml' file underneath the .git
     # folder of the calling repository already, so we can use that.
     - name: Configure workflow
-      shell: python
       env:
         DOCKER_IMAGE_TAG: ${{ inputs.docker-tag }}
-      run: |
-          import os
-          import re
-          from pathlib import Path
-
-          # Bail out if there are any illegal characters in the tag
-          tag = os.environ.get("DOCKER_IMAGE_TAG")
-          if re.search(r"[^a-zA-Z0-9_.\-]", tag):
-              raise ValueError(f"Problem with the tag `{tag}`!")
-
-          template = Path(
-              os.environ.get("GITHUB_ACTION_PATH"), "template", "action.yml"
-          )
-
-          Path(".git/action.yml").write_text(
-              template.read_text(encoding="utf-8").replace(
-                  "DOCKER_IMAGE_TAG", tag
-              ),
-              encoding="utf-8"
-          )
+      run: python '${{ github.action_path }}/create_template.py'
 
     - name: Run checks
       uses: ./.git

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
     - name: Configure workflow
       env:
         DOCKER_IMAGE_TAG: ${{ inputs.docker-tag }}
+      shell: bash
       run: python '${{ github.action_path }}/create_template.py'
 
     - name: Run checks

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # The exact version doesn't matter, so just use whatever is already
-    # available in the runner
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
 
     # https://github.com/orgs/community/discussions/9049#discussioncomment-4239509
     # Due to limitations on composite Actions, we can't do something like:

--- a/create_template.py
+++ b/create_template.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"Generate an action.yml file from the template."
+import os
+import re
+from pathlib import Path
+
+# Bail out if there are any illegal characters in the tag
+tag = os.environ.get("DOCKER_IMAGE_TAG")
+if re.search(r"[^a-zA-Z0-9_.\-]", tag):
+    raise ValueError(f"Problem with the tag `{tag}`!")
+
+template = Path(os.environ.get("GITHUB_ACTION_PATH"), "template", "action.yml")
+output_file = Path(os.environ.get("GITHUB_WORKSPACE"), ".git", "action.yml")
+
+output_file.write_text(
+    template.read_text(encoding="utf-8").replace(
+        "DOCKER_IMAGE_TAG", tag
+    ),
+    encoding="utf-8"
+)


### PR DESCRIPTION
# Description
This moves the python code from the workflow file into a separate script for easier linting.

I tested this with https://github.com/uclahs-cds/user-nwiltsie/pull/16 and confirmed that it still works as expected.

### Closes #2

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

