### PR TITLE
Prepare for version `1.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,25 @@
 # Changelog
+
 All notable changes to the static analysis Action.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
----
+## [1.0.1] - 2025-03-17
 
-## [Unreleased]
+### Changed
 
-## Changed
 - "Dogfood" action to check itself
 - Move python code out of workflow file
 - Change default docker tag from `latest` to `v1.0.1`
 
-## [v1.0.0] - 2024-04-18
+## [1.0.0] - 2024-04-18
 
 ### Added
+
 - Add README documentation about usage and versioning
 - Bootstrap Action for static analysis
+
+[1.0.0]: https://github.com/uclahs-cds/tool-static-analysis/releases/tag/v1.0.0
+[1.0.1]: https://github.com/uclahs-cds/tool-static-analysis/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
Update CHANGELOG in preparation for release **1.0.1**.

Merging this PR will trigger another workflow to create the release tag **v1.0.1**.

| Input | Value |
| ----- | ----- |
| Actor | @nwiltsie |
| Branch | `main` |
| Bump Type | `patch` |
